### PR TITLE
Remove extra level of indirection from cuMemFreeHost

### DIFF
--- a/ros/src/computing/perception/detection/lib/image/dpm_ocv/gpu/matching_gpu.cpp
+++ b/ros/src/computing/perception/detection/lib/image/dpm_ocv/gpu/matching_gpu.cpp
@@ -687,9 +687,9 @@ static void distanceTransform(int numLevels, int n, int max_size,
             }
         }
     }
-    cuMemFreeHost(&tmp_disposition.score);
-    cuMemFreeHost(&tmp_disposition.x);
-    cuMemFreeHost(&tmp_disposition.y);
+    cuMemFreeHost(tmp_disposition.score);
+    cuMemFreeHost(tmp_disposition.x);
+    cuMemFreeHost(tmp_disposition.y);
 
     for (i = 0; i < DISTANCE_TRANSFORM_STREAMS; i++)
     {

--- a/ros/src/computing/perception/detection/lib/image/dpm_ocv/gpu/matching_gpu.cpp
+++ b/ros/src/computing/perception/detection/lib/image/dpm_ocv/gpu/matching_gpu.cpp
@@ -662,10 +662,14 @@ static void distanceTransform(int numLevels, int n, int max_size,
         if (isNew == true)
         {
             size = (diffX + 1) * (diffY + 1);
-            cuMemAlloc(&dev_distTransWork[l], sizeof(DistTransWork) * size);
-            cuMemAlloc(&dev_distTransScore[l], sizeof(float) * size);
-            cuMemAlloc(&dev_x[l], sizeof(int) * size);
-            cuMemAlloc(&dev_y[l], sizeof(int) * size);
+            CUResult res = cuMemAlloc(&dev_distTransWork[l], sizeof(DistTransWork) * size);
+            CUDA_CHECK(res, "cuMemAlloc(&dev_distTransWork[l])");
+            res = cuMemAlloc(&dev_distTransScore[l], sizeof(float) * size);
+            CUDA_CHECK(res, "cuMemAlloc(&dev_distTransScore[l])");
+            res = cuMemAlloc(&dev_x[l], sizeof(int) * size);
+            CUDA_CHECK(res, "cuMemAlloc(&dev_x[l])");
+            res = cuMemAlloc(&dev_y[l], sizeof(int) * size);
+            CUDA_CHECK(res, "cuMemAlloc(&dev_y[l])");
         }
 
         DistanceTransformTwoDimensionalProblemGPU(all_F[i + 1], map[k],
@@ -687,9 +691,12 @@ static void distanceTransform(int numLevels, int n, int max_size,
             }
         }
     }
-    cuMemFreeHost(tmp_disposition.score);
-    cuMemFreeHost(tmp_disposition.x);
-    cuMemFreeHost(tmp_disposition.y);
+    CUResult res = cuMemFreeHost(tmp_disposition.score);
+    CUDA_CHECK(res, "cuMemFreeHost(tmp_disposition.score)");
+    res = cuMemFreeHost(tmp_disposition.x);
+    CUDA_CHECK(res, "cuMemFreeHost(tmp_disposition.x)");
+    res = cuMemFreeHost(tmp_disposition.y);
+    CUDA_CHECK(res, "cuMemFreeHost(tmp_disposition.y)");
 
     for (i = 0; i < DISTANCE_TRANSFORM_STREAMS; i++)
     {


### PR DESCRIPTION
`cuda-memcheck` complained about a failure to free, and no doubt the memory leak would soon lead to more problems.

(BTW, use of `CUDA_CHECK` would have detected this issue earlier.)